### PR TITLE
Added the /svmesh endpoints 

### DIFF
--- a/ngsupport/app.py
+++ b/ngsupport/app.py
@@ -30,11 +30,38 @@ app = Flask(__name__)
 #CORS(app, origins=[r'.*\.janelia\.org', r'neuroglancer-demo\.appspot\.com'], supports_credentials=True)
 CORS(app)
 
+#
+# FIXME:
+#   I'm sure this is not the idiomatic way to implement a big flask app.
+#   Rather than implementing all of our endpoints here and then calling out
+#   to separate files, there must be a simple and idiomatic way to implement
+#   endpoints in separate files.
+#
+
 
 @app.route('/small-mesh')
 def _small_mesh():
     from ngsupport.small_mesh import generate_and_store_mesh
     return generate_and_store_mesh()
+
+
+@app.route('/svmesh/<server>/<uuid>/<instance>/info')
+@app.route('/svmesh/<server>/<uuid>/<instance>/<segment_type>/info')
+def _svmesh_info(server, uuid, instance, segment_type):
+    from ngsupport.svmesh import svmesh_info
+    return svmesh_info()
+
+
+@app.route('/svmesh/<server>/<uuid>/<instance>/<segment_type>/<segment_id>:0')
+def _svmesh_manifest(server, uuid, instance, segment_type, segment_id):
+    from ngsupport.svmesh import svmesh_manifest
+    return svmesh_manifest(segment_id)
+
+
+@app.route('/svmesh/<server>/<uuid>/<instance>/<segment_type>/meshes/<int:segment_id>.ngmesh')
+def _svmesh_ngmesh(server, uuid, instance, segment_type, segment_id):
+    from ngsupport.svmesh import svmesh_ngmesh
+    return svmesh_ngmesh(server, uuid, instance, segment_type, segment_id)
 
 
 @app.route('/block-mesh', methods=['POST'])
@@ -47,7 +74,7 @@ def _block_mesh():
 def _locate_body():
     from ngsupport.locate_body import locate_body
     return locate_body()
-    
+
 
 @app.route('/neuronjson_segment_properties/<server>/<uuid>/<instance>/<label>/info')
 @app.route('/neuronjson_segment_properties/<server>/<uuid>/<instance>/<label>/<altlabel>/info')

--- a/ngsupport/svmesh.py
+++ b/ngsupport/svmesh.py
@@ -1,0 +1,77 @@
+import functools
+from flask import make_response, jsonify
+from neuclease.dvid import fetch_info, fetch_tarfile, fetch_supervoxel
+from vol2mesh import Mesh
+
+
+def svmesh_info():
+    return jsonify({"@type": "neuroglancer_legacy_mesh"})
+
+
+def svmesh_manifest(segment_id):
+    return jsonify({"fragments": [f"meshes/{segment_id}.ngmesh"]})
+
+
+def svmesh_ngmesh(server, uuid, instance, segment_type, segment_id):
+    """
+    Generate a mesh (in ngmesh format) for a supervoxel or body.
+
+    If a supervoxel mesh is requested, we fetch it directly from the
+    given tarsupervoxels instance.
+
+    If a body mesh is requested, we fetch the entire tarfile of
+    supervoxel meshes from the given tarsupervoxels instance and
+    construct a single ngmesh from their union.
+
+    Parameters
+    ----------
+    dvid:
+        dvid server. Required.
+
+    uuid:
+        Dvid uuid to read from and write to.
+
+    instance:
+        Name of the tarsupervoxels instance to read from.
+        If the instance ends with the suffix '?supervoxels=true',
+        then we'll fetch a supervoxel mesh instead of a body mesh.
+
+    segment_type:
+        Either 'body' or 'supervoxels' (supervoxel).
+
+    segment_id:
+        Either a body ID or supervoxel ID, depending on whether the instance ends with '?supervoxels=true'.
+
+    Returns
+    -------
+    The contents of the generated ngmesh.
+    """
+    if segment_type in ('sv', 'supervoxel', 'supervoxels'):
+        try:
+            drc_bytes = fetch_supervoxel(server, uuid, instance, segment_id)
+        except Exception as e:
+            return jsonify({"error": str(e)}), 404
+        mesh = Mesh.from_buffer(drc_bytes, fmt='drc')
+    else:
+        try:
+            tarfile = fetch_tarfile(server, uuid, instance, segment_id)
+        except Exception as e:
+            return jsonify({"error": str(e)}), 404
+        mesh = Mesh.from_tarfile(tarfile)
+
+    if len(mesh.vertices_zyx) == 0:
+        return jsonify({"error": "No vertices found in tarfile"}), 404
+
+    mesh.vertices_zyx *= get_dataset_resolution_zyx(server, uuid, instance)
+    ngmesh_bytes = mesh.serialize(fmt='ngmesh')
+    r = make_response(ngmesh_bytes)
+    r.headers.set('Content-Type', 'application/octet-stream')
+    return r
+
+
+@functools.cache
+def get_dataset_resolution_zyx(server, uuid, tsv_instance):
+    tsv_info = fetch_info(server, uuid, tsv_instance)
+    seg_instance = tsv_info['Base']['Syncs'][0]
+    seg_info = fetch_info(server, uuid, seg_instance)
+    return seg_info['Extended']['VoxelSize'][::-1]


### PR DESCRIPTION
...for producing neuroglancer meshes from a DVID tarsupervoxels instance.  This is useful for debugging the meshes that neu3 uses.

To use it, add a new "source" in your neuroglancer segmentation layer settings, with a url like this (assuming you're looking at a supervoxel segmentation, e.g. with `supervoxels=true` in your main source):

```
precomputed://https://ngsupport-bmcp5imp6q-uk.a.run.app/svmesh/my-dvid-server.janelia.org/634ee:master/segmentation_sv_meshes/supervoxels
```

or ending with `body` to see the aggregate meshes in the case of a body segmentation


```
precomputed://https://ngsupport-bmcp5imp6q-uk.a.run.app/svmesh/my-dvid-server.janelia.org/634ee:master/segmentation_sv_meshes/body
```


cc @olbris @DocSavage @StephanPreibisch